### PR TITLE
Adding Parameters as a field on baseamqp with setter and getter

### DIFF
--- a/lib/Thumper/BaseAmqp.php
+++ b/lib/Thumper/BaseAmqp.php
@@ -39,6 +39,9 @@ use PhpAmqpLib\Connection\AbstractConnection;
 
 abstract class BaseAmqp
 {
+
+    const NONPERSISTENT = 1;
+    const PERSISTENT = 2;
     /**
      * @var AbstractConnection
      */
@@ -87,6 +90,13 @@ abstract class BaseAmqp
      * @var string
      */
     protected $routingKey = '';
+
+    /**
+     * @var array
+     */
+    protected $parameters = array(
+        'content_type' => 'text/plain'
+    );
 
     /**
      * BaseAmqp constructor.
@@ -225,5 +235,22 @@ abstract class BaseAmqp
     private function isValidExchangeName($exchangeName)
     {
         return preg_match('/^[A-Za-z0-9_\-\.\;]*$/', $exchangeName);
+    }
+
+    /**
+     * @param string $key
+     * @param string $value
+     */
+    public function setParameter($key, $value)
+    {
+        $this->parameters[$key] = $value;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->parameters;
     }
 }

--- a/lib/Thumper/Producer.php
+++ b/lib/Thumper/Producer.php
@@ -61,10 +61,12 @@ class Producer extends BaseAmqp
             }
             $this->exchangeReady = true;
         }
+        
+        $this->setParameter('delivery_mode', self::PERSISTENT);
 
         $message = new AMQPMessage(
             $messageBody,
-            array('content_type' => 'text/plain', 'delivery_mode' => 2)
+            $this->getParameters()
         );
         $this->channel->basic_publish(
             $message,

--- a/lib/Thumper/RpcClient.php
+++ b/lib/Thumper/RpcClient.php
@@ -80,14 +80,12 @@ class RpcClient extends BaseAmqp
         if (empty($requestId)) {
             throw new \InvalidArgumentException("You must provide a request ID");
         }
+        $this->setParameter('correlation_id', $requestId);
+        $this->setParameter('reply_to', $this->queueName);
 
         $message = new AMQPMessage(
             $messageBody,
-            array(
-                'content_type' => 'text/plain',
-                'reply_to' => $this->queueName,
-                'correlation_id' => $requestId
-            )
+            $this->getParameters()
         );
 
         $this->channel

--- a/lib/Thumper/RpcServer.php
+++ b/lib/Thumper/RpcServer.php
@@ -103,12 +103,10 @@ class RpcServer extends BaseConsumer
      */
     protected function sendReply($result, $client, $correlationId)
     {
+        $this->setParameter('correlation_id', $correlationId);
         $reply = new AMQPMessage(
             $result,
-            array(
-                'content_type' => 'text/plain',
-                'correlation_id' => $correlationId
-            )
+            $this->getParameters()
         );
         $this->channel
             ->basic_publish($reply, '', $client);


### PR DESCRIPTION
This allows the client to set any of the message parameters including content type (currently it is hard coded to text/plain)